### PR TITLE
masks and disabled service, unapply is idempotent

### DIFF
--- a/mitigate.cve-2024-47176.yml
+++ b/mitigate.cve-2024-47176.yml
@@ -5,6 +5,27 @@
   become: True
   vars:
     real_apply_mitigation: "{{ apply_mitigation | default(True) | bool }}"
+    # map service_facts.state to systemd_service.state
+    playbook_state_map:
+      failed: stopped
+      running: started
+      stopped: stopped
+      unknown: stopped
+      inactive: stopped
+    # map service_facts.status to systemd_service.enabled
+    playbook_status_map:
+      enabled: True
+      disabled: False
+      static: True
+      indirect: False
+      unknown: False
+      masked: False
+    # extract current service state and status
+    get_current_state: '{{ services["cups-browsed.service"].state | default("stopped") }}'
+    get_current_status: '{{ services["cups-browsed.service"].status | default("disabled") }}'
+    # convert service state and status to systemd state and enabled
+    get_new_state: '{{ "stopped" if real_apply_mitigation else playbook_state_map[get_current_state] | default("stopped") }}'
+    get_new_enabled: '{{ False if real_apply_mitigation else playbook_status_map[get_current_status] | default(False) }}'
 
   handlers: []
 
@@ -35,13 +56,22 @@
         state: '{{ "enabled" if real_apply_mitigation else "disabled" }}'
       when: cups_filter_installed is not skipped
 
-    # unapplying the mitigation does not unmask the service
+    - name: get cups-browsed service info
+      ansible.builtin.service_facts:
+
     - name: stop + disable cups-browsed service
       ansible.builtin.systemd_service:
         name: cups-browsed
-        state: stopped
-        masked: true
-        enabled: false
+        state: '{{ get_new_state }}'
+        enabled: '{{ get_new_enabled }}'
       when:
-        - real_apply_mitigation
+        - cups_filter_installed is not skipped
+
+    - name: stop + disable + mask cups-browsed service
+      ansible.builtin.systemd_service:
+        name: cups-browsed
+        state: '{{ get_new_state }}'
+        enabled: '{{ get_new_enabled }}'
+        masked: '{{ real_apply_mitigation }}'
+      when:
         - cups_filter_installed is not skipped


### PR DESCRIPTION
resolves #1 and #2

Need to run the systemd_service module twice:

1. to disable and stop the service
2. to disable, stop, and mask the service

Failing to mask the service last renders the service automatically enabled if it was enabled previously, and then manually unmasked.

Added service_facts module to ensure idempotency of playbook when mitigation is unapplied and then further configuration changes are performed on the host.